### PR TITLE
Master

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20181105040015) do
 
   create_table "images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "image_url"
+    t.integer "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
##WHAT
rake db:rollback, and then rake db:migrate

##WHY
When I did rake db:migrate,  automatically item_id disappeared.