### PR TITLE
Uninstall dropzonejs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ gem 'jp_prefecture'
 gem 'simple_form'  #formをすっきり書けます
 gem 'payjp'
 gem 'mini_magick'
-gem 'dropzonejs-rails'
 gem 'carrierwave', '~> 1.0'
 gem 'mechanize'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,8 +96,6 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dropzonejs-rails (0.8.2)
-      rails (> 3.1)
     erb2haml (0.1.5)
       html2haml
     erubi (1.7.1)
@@ -351,7 +349,6 @@ DEPENDENCIES
   carrierwave (~> 1.0)
   coffee-rails (~> 4.2)
   devise
-  dropzonejs-rails
   erb2haml
   factory_bot_rails
   factory_girl_rails (~> 4.4.1)


### PR DESCRIPTION
##WHAT
Uninstall dropzonejs by terminal.
I deleted the 'gem dropzonejs-rails’ code.
Bundle install by command line.
##WHY
Dropzone.js can not save multiple information together with images.